### PR TITLE
Use correct form of Blunder/Mistake/Inaccuracy in analysis

### DIFF
--- a/ui/analyse/src/acpl.ts
+++ b/ui/analyse/src/acpl.ts
@@ -72,7 +72,7 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
                   'data-symbol': a.symbol,
                 }
               : {};
-            return h('tr' + (nb ? '.symbol' : ''), { attrs }, [h('td', '' + nb), h('th', trans(a.plural))]);
+            return h('tr' + (nb ? '.symbol' : ''), { attrs }, [h('td', '' + nb), h('th', trans(nb == 1 ? a.kind : a.plural))]);
           })
           .concat(h('tr', [h('td', '' + (defined(acpl) ? acpl : '?')), h('th', trans('averageCentipawnLoss'))]))
       ),


### PR DESCRIPTION
This PR checks if Blunder/Mistake/Inaccuracy should be singular or plural in the computer analysis screen. If there is exactly one Blunder/Mistake/Inaccuracy, the singular is used, otherwise the plural is used. Currently, only the plural is used, leading to cases like `1 Inaccuracies`. See the screenshot below.

Note: I was not able to verify this change works when compiling from source and running a local server. I tried importing a game with annotations and viewing the analysis to no avail. Any assistance with this would be appreciated (though it may not be necessary with such a small change).

-----------------------------------------------------------------------------------------------------------------------------------------

![lichess_analysis](https://user-images.githubusercontent.com/6856636/113236979-d436b880-925a-11eb-81de-85eadb061d33.png)
